### PR TITLE
feat(next): Ф2 HUD streak/XP + лидерборд (8795)

### DIFF
--- a/next/app/[locale]/learn/leaderboard/page.tsx
+++ b/next/app/[locale]/learn/leaderboard/page.tsx
@@ -1,9 +1,28 @@
-import type { ReactElement } from 'react';
+import { Suspense, type ReactElement } from 'react';
 import { setRequestLocale, getTranslations } from 'next-intl/server';
 import { LeaderboardView } from '@/components/learn/leaderboard';
 
 interface LeaderboardPageProps {
   params: { locale: string };
+}
+
+/** Skeleton shown while LeaderboardView (which calls useSearchParams) hydrates. */
+function LeaderboardSkeleton() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxWidth: 680, margin: '0 auto' }}>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div
+          key={i}
+          style={{
+            height: 52,
+            borderRadius: 'var(--r-md)',
+            background: 'var(--surface-2)',
+            animation: 'pulse-soft 1.4s ease-in-out infinite',
+          }}
+        />
+      ))}
+    </div>
+  );
 }
 
 export default async function LeaderboardPage({ params }: LeaderboardPageProps): Promise<ReactElement> {
@@ -13,7 +32,11 @@ export default async function LeaderboardPage({ params }: LeaderboardPageProps):
 
   return (
     <div className="container fade-up" style={{ paddingTop: 40, paddingBottom: 80 }}>
-      <LeaderboardView />
+      {/* Suspense boundary required: LeaderboardView calls useSearchParams() which
+          opts the subtree out of static prerendering in Next 14. */}
+      <Suspense fallback={<LeaderboardSkeleton />}>
+        <LeaderboardView />
+      </Suspense>
       {/* Hidden h1 for screen readers; the client component renders its own heading */}
       <h1 className="sr-only">{t('title')}</h1>
     </div>

--- a/next/app/[locale]/learn/leaderboard/page.tsx
+++ b/next/app/[locale]/learn/leaderboard/page.tsx
@@ -1,0 +1,21 @@
+import type { ReactElement } from 'react';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { LeaderboardView } from '@/components/learn/leaderboard';
+
+interface LeaderboardPageProps {
+  params: { locale: string };
+}
+
+export default async function LeaderboardPage({ params }: LeaderboardPageProps): Promise<ReactElement> {
+  setRequestLocale(params.locale);
+  // Pre-resolve translations for metadata; the client component loads its own via useTranslations.
+  const t = await getTranslations('learn.leaderboard');
+
+  return (
+    <div className="container fade-up" style={{ paddingTop: 40, paddingBottom: 80 }}>
+      <LeaderboardView />
+      {/* Hidden h1 for screen readers; the client component renders its own heading */}
+      <h1 className="sr-only">{t('title')}</h1>
+    </div>
+  );
+}

--- a/next/app/globals.css
+++ b/next/app/globals.css
@@ -214,6 +214,10 @@ h2 { font-weight: 700; }
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+@keyframes fadeDown {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(8px); }
+}
 @keyframes pulse-soft {
   0%, 100% { transform: scale(1); opacity: 1; }
   50% { transform: scale(1.04); opacity: 0.85; }

--- a/next/app/globals.css
+++ b/next/app/globals.css
@@ -301,6 +301,8 @@ h2 { font-weight: 700; }
 
 /* Hide on small */
 .hide-sm { display: initial; }
+/* Complement: hidden by default, visible on small (≤720px) — same breakpoint as .hide-sm */
+.show-sm { display: none !important; }
 
 /* Buryat keyboard adapts on narrow screens: tighter padding, smaller keys,
    and the special-key labels (tab/caps/shift/enter/backspace) get clipped
@@ -448,6 +450,7 @@ h2 { font-weight: 700; }
   .phrase-row > div:nth-child(3) { justify-content: flex-start !important; }
 
   .hide-sm { display: none !important; }
+  .show-sm { display: inline-flex !important; }
 
   .card { padding: 16px !important; }
 

--- a/next/app/globals.css
+++ b/next/app/globals.css
@@ -24,6 +24,8 @@
   --accent-warm-soft: #FFF4B8;
   --accent-green: #2D8659;     /* приглушённый, для success */
   --accent-green-soft: #D4ECD9;
+  --bronze: #CD7F32;           /* подиум — бронза (лидерборд) */
+  --bronze-soft: #F5E6D3;
 
   --neutral-1000: #0E1013;
   --neutral-900: #1A1C1E;
@@ -109,6 +111,8 @@
   --tertiary-soft: #4A2A2A;
   --accent-warm-soft: #3D2E15;
   --accent-green-soft: #1F3D2F;
+  --bronze: #D4924A;           /* подиум — бронза (лидерборд, тёмная тема) */
+  --bronze-soft: #2E1F0A;
 }
 
 * { box-sizing: border-box; }

--- a/next/components/header.tsx
+++ b/next/components/header.tsx
@@ -9,6 +9,7 @@ import { Icon } from '@/components/ui/icon';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 import { getAuthToken } from '@/lib/api/cookies';
 import * as user from '@/lib/api/user';
+import { GamificationHud } from '@/components/learn/gamification-hud';
 
 type NavItem = {
   id: 'home' | 'dictionary' | 'names' | 'packs' | 'quiz';
@@ -135,6 +136,11 @@ export function Header() {
         </button>
 
         <div style={{ flex: 1 }} />
+
+        {/* Gamification HUD — streak / XP / level, hidden for guests */}
+        <span className="hide-sm" style={{ display: 'inline-flex' }}>
+          <GamificationHud signedIn={signedIn} />
+        </span>
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <button

--- a/next/components/header.tsx
+++ b/next/components/header.tsx
@@ -76,18 +76,25 @@ export function Header() {
   }, []);
 
   // One gamification fetch feeds both desktop and mobile HUD variants.
+  // Re-fires on pathname change so XP/streak are fresh after /learn sessions
+  // without a full page reload. Shows the loading skeleton only on the very
+  // first load (gamification === null); subsequent navigations update silently
+  // in the background to avoid a jarring flicker.
   useEffect(() => {
     if (!signedIn) {
       setGamificationLoading(false);
       return;
     }
+    // Show skeleton only while we have no data yet.
+    if (gamification === null) setGamificationLoading(true);
     getGamificationMe()
       .then(setGamification)
       .catch(() => {
         // silently hide on error — HUD is non-critical
       })
       .finally(() => setGamificationLoading(false));
-  }, [signedIn]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signedIn, pathname]);
 
   const currentTheme: 'light' | 'dark' = resolvedTheme === 'dark' ? 'dark' : 'light';
 

--- a/next/components/header.tsx
+++ b/next/components/header.tsx
@@ -10,6 +10,8 @@ import { LocaleSwitcher } from '@/components/locale-switcher';
 import { getAuthToken } from '@/lib/api/cookies';
 import * as user from '@/lib/api/user';
 import { GamificationHud, GamificationHudMobile } from '@/components/learn/gamification-hud';
+import { getGamificationMe } from '@/lib/api/gamification';
+import type { GamificationMe } from '@/lib/api/gamification';
 
 type NavItem = {
   id: 'home' | 'dictionary' | 'names' | 'packs' | 'quiz';
@@ -38,6 +40,9 @@ export function Header() {
   const [signedIn, setSignedIn] = useState(false);
   const [initials, setInitials] = useState('У');
   const [menuOpen, setMenuOpen] = useState(false);
+  // Single gamification fetch — shared by both HUD variants to avoid duplicate requests.
+  const [gamification, setGamification] = useState<GamificationMe | null>(null);
+  const [gamificationLoading, setGamificationLoading] = useState(true);
 
   // Close drawer when route changes — otherwise tapping a link leaves the
   // drawer hanging open over the new page.
@@ -69,6 +74,20 @@ export function Header() {
         // ignore — keep default initials
       });
   }, []);
+
+  // One gamification fetch feeds both desktop and mobile HUD variants.
+  useEffect(() => {
+    if (!signedIn) {
+      setGamificationLoading(false);
+      return;
+    }
+    getGamificationMe()
+      .then(setGamification)
+      .catch(() => {
+        // silently hide on error — HUD is non-critical
+      })
+      .finally(() => setGamificationLoading(false));
+  }, [signedIn]);
 
   const currentTheme: 'light' | 'dark' = resolvedTheme === 'dark' ? 'dark' : 'light';
 
@@ -137,14 +156,15 @@ export function Header() {
 
         <div style={{ flex: 1 }} />
 
-        {/* Gamification HUD — streak / XP / level, hidden for guests */}
+        {/* Gamification HUD — streak / XP / level, hidden for guests.
+            Both variants share the same fetched data to avoid duplicate requests. */}
         {/* Desktop strip (≥720px): streak · XP · CEFR badge */}
         <span className="hide-sm" style={{ display: 'inline-flex' }}>
-          <GamificationHud signedIn={signedIn} />
+          <GamificationHud signedIn={signedIn} stats={gamification} loading={gamificationLoading} />
         </span>
         {/* Mobile chip (≤720px): 🔥streak · XP in one compact chip */}
         <span className="show-sm">
-          <GamificationHudMobile signedIn={signedIn} />
+          <GamificationHudMobile signedIn={signedIn} stats={gamification} />
         </span>
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>

--- a/next/components/header.tsx
+++ b/next/components/header.tsx
@@ -9,7 +9,7 @@ import { Icon } from '@/components/ui/icon';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 import { getAuthToken } from '@/lib/api/cookies';
 import * as user from '@/lib/api/user';
-import { GamificationHud } from '@/components/learn/gamification-hud';
+import { GamificationHud, GamificationHudMobile } from '@/components/learn/gamification-hud';
 
 type NavItem = {
   id: 'home' | 'dictionary' | 'names' | 'packs' | 'quiz';
@@ -138,8 +138,13 @@ export function Header() {
         <div style={{ flex: 1 }} />
 
         {/* Gamification HUD — streak / XP / level, hidden for guests */}
+        {/* Desktop strip (≥720px): streak · XP · CEFR badge */}
         <span className="hide-sm" style={{ display: 'inline-flex' }}>
           <GamificationHud signedIn={signedIn} />
+        </span>
+        {/* Mobile chip (≤720px): 🔥streak · XP in one compact chip */}
+        <span className="show-sm">
+          <GamificationHudMobile signedIn={signedIn} />
         </span>
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>

--- a/next/components/learn/gamification-hud.tsx
+++ b/next/components/learn/gamification-hud.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import { Icon } from '@/components/ui/icon';
-import { getGamificationMe } from '@/lib/api/gamification';
 import type { GamificationMe } from '@/lib/api/gamification';
 
 /** Maps numeric level to a CEFR badge label. */
@@ -13,28 +11,22 @@ function levelLabel(level: number): string {
   return labels[Math.min(level - 1, labels.length - 1)] ?? 'A1';
 }
 
+interface GamificationHudProps {
+  signedIn: boolean;
+  /** Resolved stats from parent; null while loading or on error. */
+  stats: GamificationMe | null;
+  /** True while the parent is still fetching. */
+  loading: boolean;
+}
+
 /**
  * Compact gamification status strip for the global header.
  * Shows 🔥 streak · ◆ XP · level badge.
  * Hidden for guests (renders nothing when signedIn=false).
+ * Data is fetched once by the parent Header and passed in to avoid duplicate requests.
  */
-export function GamificationHud({ signedIn }: { signedIn: boolean }) {
+export function GamificationHud({ signedIn, stats, loading }: GamificationHudProps) {
   const t = useTranslations('learn.hud');
-  const [stats, setStats] = useState<GamificationMe | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!signedIn) {
-      setLoading(false);
-      return;
-    }
-    getGamificationMe()
-      .then(setStats)
-      .catch(() => {
-        // silently hide on error — HUD is non-critical
-      })
-      .finally(() => setLoading(false));
-  }, [signedIn]);
 
   if (!signedIn) return null;
 
@@ -123,20 +115,19 @@ export function GamificationHud({ signedIn }: { signedIn: boolean }) {
   );
 }
 
+interface GamificationHudMobileProps {
+  signedIn: boolean;
+  /** Resolved stats from parent; null while loading or on error. */
+  stats: GamificationMe | null;
+}
+
 /**
  * Compact mobile version: "🔥7 · 1240 XP" in a single chip.
  * Rendered at ≤640px via CSS, desktop version hidden there.
+ * Data is fetched once by the parent Header and passed in to avoid duplicate requests.
  */
-export function GamificationHudMobile({ signedIn }: { signedIn: boolean }) {
+export function GamificationHudMobile({ signedIn, stats }: GamificationHudMobileProps) {
   const t = useTranslations('learn.hud');
-  const [stats, setStats] = useState<GamificationMe | null>(null);
-
-  useEffect(() => {
-    if (!signedIn) return;
-    getGamificationMe()
-      .then(setStats)
-      .catch(() => {/* silently hide */});
-  }, [signedIn]);
 
   if (!signedIn || !stats) return null;
 

--- a/next/components/learn/gamification-hud.tsx
+++ b/next/components/learn/gamification-hud.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { Icon } from '@/components/ui/icon';
+import { getGamificationMe } from '@/lib/api/gamification';
+import type { GamificationMe } from '@/lib/api/gamification';
+
+/** Maps numeric level to a CEFR badge label. */
+function levelLabel(level: number): string {
+  const labels = ['A1', 'A2', 'B1', 'B2', 'C1'];
+  return labels[Math.min(level - 1, labels.length - 1)] ?? 'A1';
+}
+
+/**
+ * Compact gamification status strip for the global header.
+ * Shows 🔥 streak · ◆ XP · level badge.
+ * Hidden for guests (renders nothing when signedIn=false).
+ */
+export function GamificationHud({ signedIn }: { signedIn: boolean }) {
+  const t = useTranslations('learn.hud');
+  const [stats, setStats] = useState<GamificationMe | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!signedIn) {
+      setLoading(false);
+      return;
+    }
+    getGamificationMe()
+      .then(setStats)
+      .catch(() => {
+        // silently hide on error — HUD is non-critical
+      })
+      .finally(() => setLoading(false));
+  }, [signedIn]);
+
+  if (!signedIn) return null;
+
+  if (loading) {
+    // Skeleton pills
+    return (
+      <div
+        style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+        aria-hidden="true"
+      >
+        {[44, 60, 36].map((w) => (
+          <div
+            key={w}
+            className="animation-pulse-soft"
+            style={{
+              width: w,
+              height: 24,
+              borderRadius: 999,
+              background: 'var(--surface-2)',
+              animation: 'pulse-soft 1.4s ease-in-out infinite',
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (!stats) return null;
+
+  const atRisk = !stats.goal_met && stats.streak > 0;
+  const streakColor = stats.streak === 0 ? 'var(--text-muted)' : 'var(--accent-warm)';
+
+  return (
+    <Link
+      href="/learn/leaderboard"
+      aria-label={t('ariaLabel', {
+        streak: stats.streak,
+        xp: stats.xp,
+        level: levelLabel(stats.level),
+      })}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        textDecoration: 'none',
+        color: 'inherit',
+      }}
+    >
+      {/* Streak */}
+      <span
+        title={atRisk ? t('streakAtRisk') : undefined}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          color: streakColor,
+          fontWeight: 700,
+          fontSize: 13,
+          animation: atRisk ? 'pulse-soft 2s ease-in-out infinite' : undefined,
+        }}
+      >
+        <Icon name="flame" size={14} />
+        {stats.streak}
+      </span>
+
+      {/* XP */}
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          color: 'var(--primary)',
+          fontWeight: 700,
+          fontSize: 13,
+        }}
+      >
+        <Icon name="zap" size={14} />
+        {stats.xp.toLocaleString()}
+      </span>
+
+      {/* CEFR level badge */}
+      <span className="chip chip-primary" style={{ padding: '3px 8px', fontSize: 11 }}>
+        {levelLabel(stats.level)}
+      </span>
+    </Link>
+  );
+}
+
+/**
+ * Compact mobile version: "🔥7 · 1240 XP" in a single chip.
+ * Rendered at ≤640px via CSS, desktop version hidden there.
+ */
+export function GamificationHudMobile({ signedIn }: { signedIn: boolean }) {
+  const t = useTranslations('learn.hud');
+  const [stats, setStats] = useState<GamificationMe | null>(null);
+
+  useEffect(() => {
+    if (!signedIn) return;
+    getGamificationMe()
+      .then(setStats)
+      .catch(() => {/* silently hide */});
+  }, [signedIn]);
+
+  if (!signedIn || !stats) return null;
+
+  return (
+    <Link
+      href="/learn/leaderboard"
+      className="chip chip-warm"
+      aria-label={t('ariaLabel', {
+        streak: stats.streak,
+        xp: stats.xp,
+        level: levelLabel(stats.level),
+      })}
+      style={{
+        textDecoration: 'none',
+        minHeight: 44,
+        padding: '0 14px',
+        fontSize: 13,
+        fontWeight: 700,
+        gap: 6,
+      }}
+    >
+      <Icon name="flame" size={13} />
+      {stats.streak} · {stats.xp.toLocaleString()}
+    </Link>
+  );
+}

--- a/next/components/learn/leaderboard.tsx
+++ b/next/components/learn/leaderboard.tsx
@@ -1,0 +1,406 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Link } from '@/i18n/navigation';
+import { Icon } from '@/components/ui/icon';
+import { getLeaderboard } from '@/lib/api/gamification';
+import type { LeaderboardRow, LeaderboardMe, LeaderboardPeriod } from '@/lib/api/gamification';
+
+type LeaderboardState = 'loading' | 'error' | 'empty' | 'active';
+
+const PERIODS: { id: LeaderboardPeriod; labelKey: string }[] = [
+  { id: 'week', labelKey: 'periodWeek' },
+  { id: 'all', labelKey: 'periodAll' },
+];
+
+/** Maps rank 1/2/3 to podium colours. */
+function podiumColor(rank: number): string {
+  if (rank === 1) return 'var(--accent-warm)';
+  if (rank === 2) return 'var(--neutral-400)';
+  return 'var(--bronze)';
+}
+
+/** Delta arrow + aria-label */
+function DeltaCell({ delta, t }: { delta?: number; t: (key: string, values?: Record<string, string | number>) => string }) {
+  if (delta == null || delta === 0) {
+    return (
+      <span aria-label={t('deltaStable')} style={{ color: 'var(--text-muted)', fontSize: 13 }}>
+        —
+      </span>
+    );
+  }
+  if (delta > 0) {
+    return (
+      <span
+        aria-label={t('deltaUp', { n: delta })}
+        style={{ color: 'var(--accent-green)', fontWeight: 700, fontSize: 13 }}
+      >
+        ↑{delta}
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-label={t('deltaDown', { n: Math.abs(delta) })}
+      style={{ color: 'var(--tertiary)', fontWeight: 700, fontSize: 13 }}
+    >
+      ↓{Math.abs(delta)}
+    </span>
+  );
+}
+
+/** Avatar placeholder circle with initials. */
+function AvatarCircle({ name, size = 36 }: { name: string; size?: number }) {
+  const initial = name.trim().charAt(0).toUpperCase() || '?';
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: 'linear-gradient(135deg, var(--primary-200) 0%, var(--primary) 100%)',
+        color: 'var(--text-inv)',
+        fontWeight: 700,
+        fontSize: size * 0.4,
+        display: 'grid',
+        placeItems: 'center',
+        flexShrink: 0,
+      }}
+    >
+      {initial}
+    </div>
+  );
+}
+
+interface RowProps {
+  row: LeaderboardRow & { delta?: number };
+  isMe?: boolean;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}
+
+function RankRow({ row, isMe = false, t }: RowProps) {
+  return (
+    <div
+      aria-current={isMe ? 'true' : undefined}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 16px',
+        borderRadius: 'var(--r-md)',
+        background: isMe ? 'var(--primary-50)' : 'transparent',
+        border: isMe ? '1px solid var(--primary-100)' : '1px solid transparent',
+        minHeight: 52,
+        transition: 'background 0.15s ease',
+      }}
+    >
+      {/* Rank */}
+      <span
+        style={{
+          width: 32,
+          flexShrink: 0,
+          textAlign: 'right',
+          fontWeight: 700,
+          fontSize: 14,
+          color: isMe ? 'var(--primary-700)' : 'var(--text-muted)',
+        }}
+      >
+        #{row.rank}
+      </span>
+
+      {/* Avatar */}
+      <AvatarCircle name={row.name} size={36} />
+
+      {/* Name */}
+      <span
+        style={{
+          flex: 1,
+          fontWeight: isMe ? 700 : 500,
+          fontSize: 14,
+          color: isMe ? 'var(--primary-700)' : 'var(--text)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {isMe ? `${row.name} (${t('you')})` : row.name}
+      </span>
+
+      {/* XP */}
+      <span style={{ fontWeight: 700, fontSize: 13, color: 'var(--primary)', flexShrink: 0 }}>
+        {row.xp.toLocaleString()} XP
+      </span>
+
+      {/* Delta */}
+      <div style={{ width: 32, textAlign: 'center', flexShrink: 0 }}>
+        <DeltaCell delta={row.delta} t={t} />
+      </div>
+    </div>
+  );
+}
+
+function PodiumItem({ row, t }: { row: LeaderboardRow; t: (key: string, values?: Record<string, string | number>) => string }) {
+  const color = podiumColor(row.rank);
+  const isFirst = row.rank === 1;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 8,
+        padding: '12px 16px',
+        borderRadius: 'var(--r-lg)',
+        background: 'var(--surface)',
+        border: `2px solid ${color}`,
+        minWidth: isFirst ? 120 : 96,
+        order: isFirst ? 2 : row.rank === 2 ? 1 : 3,
+        marginTop: isFirst ? 0 : 24,
+      }}
+    >
+      <span style={{ fontSize: isFirst ? 28 : 22 }}>
+        {row.rank === 1 ? '🥇' : row.rank === 2 ? '🥈' : '🥉'}
+      </span>
+      <AvatarCircle name={row.name} size={isFirst ? 48 : 40} />
+      <span
+        style={{
+          fontWeight: 700,
+          fontSize: 13,
+          color: 'var(--text)',
+          textAlign: 'center',
+          maxWidth: 100,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {row.name}
+      </span>
+      <span style={{ fontWeight: 700, fontSize: 12, color }}>
+        {row.xp.toLocaleString()} XP
+      </span>
+    </div>
+  );
+}
+
+export function LeaderboardView() {
+  const t = useTranslations('learn.leaderboard');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const rawPeriod = searchParams.get('period') ?? 'week';
+  const period: LeaderboardPeriod = rawPeriod === 'all' ? 'all' : 'week';
+
+  const [state, setState] = useState<LeaderboardState>('loading');
+  const [rows, setRows] = useState<LeaderboardRow[]>([]);
+  const [me, setMe] = useState<LeaderboardMe | null>(null);
+
+  const load = useCallback(async () => {
+    setState('loading');
+    try {
+      const res = await getLeaderboard({ period });
+      if (res.rows.length === 0) {
+        setState('empty');
+      } else {
+        setRows(res.rows);
+        setMe(res.me);
+        setState('active');
+      }
+    } catch {
+      setState('error');
+    }
+  }, [period]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function setPeriod(p: LeaderboardPeriod) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('period', p);
+    router.replace(`?${params.toString()}`);
+  }
+
+  const podiumRows = rows.slice(0, 3);
+  const listRows = rows.slice(3);
+
+  // Find "me" row inside the full list (to highlight inline too)
+  const meRow = me ? rows.find((r) => r.rank === me.rank) : null;
+
+  // Sticky-self: me outside the top-20 visible list
+  const meIsVisible = meRow != null;
+
+  return (
+    <div style={{ maxWidth: 680, margin: '0 auto' }}>
+      {/* Header row */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20, flexWrap: 'wrap', gap: 12 }}>
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 24,
+            fontWeight: 800,
+            margin: 0,
+            color: 'var(--text)',
+          }}
+        >
+          {t('title')}
+        </h1>
+
+        {/* Period filter chips */}
+        <div style={{ display: 'flex', gap: 6 }}>
+          {PERIODS.map((p) => {
+            const isActive = period === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                className="chip"
+                style={{
+                  background: isActive ? 'var(--neutral-900)' : 'var(--surface)',
+                  color: isActive ? 'var(--text-inv)' : 'var(--text-muted)',
+                  border: isActive ? '1px solid transparent' : '1px solid var(--border)',
+                  cursor: 'pointer',
+                  minHeight: 44,
+                  padding: '0 16px',
+                  fontSize: 13,
+                }}
+                aria-pressed={isActive}
+                onClick={() => setPeriod(p.id)}
+              >
+                {t(p.labelKey)}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Scope note — friends filter is a stretch/future feature */}
+      <p style={{ fontSize: 12, color: 'var(--text-soft)', marginBottom: 16, marginTop: -8 }}>
+        {t('scopeGlobal')}
+      </p>
+
+      {/* Loading: skeleton rows */}
+      {state === 'loading' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              style={{
+                height: 52,
+                borderRadius: 'var(--r-md)',
+                background: 'var(--surface-2)',
+                animation: 'pulse-soft 1.4s ease-in-out infinite',
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Error */}
+      {state === 'error' && (
+        <div className="card" style={{ padding: 28, textAlign: 'center' }}>
+          <p style={{ color: 'var(--tertiary)', marginBottom: 14 }}>{t('error')}</p>
+          <button type="button" className="btn btn-secondary" onClick={() => void load()}>
+            {t('retry')}
+          </button>
+        </div>
+      )}
+
+      {/* Empty */}
+      {state === 'empty' && (
+        <div className="card fade-up" style={{ padding: 40, textAlign: 'center', maxWidth: 480, margin: '0 auto' }}>
+          <p style={{ color: 'var(--text-muted)', marginBottom: 20 }}>{t('empty')}</p>
+          <Link href="/learn" className="btn btn-primary">
+            {t('startLearning')}
+          </Link>
+        </div>
+      )}
+
+      {/* Active: podium + rows */}
+      {state === 'active' && (
+        <>
+          {/* Podium top-3 */}
+          {podiumRows.length >= 3 && (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'flex-end',
+                gap: 12,
+                marginBottom: 28,
+              }}
+              aria-label={t('podiumLabel')}
+            >
+              {podiumRows.map((r) => (
+                <PodiumItem key={r.rank} row={r} t={t} />
+              ))}
+            </div>
+          )}
+
+          {/* Ranked rows (rank 4+) */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {listRows.map((r) => (
+              <RankRow
+                key={r.rank}
+                row={r}
+                isMe={meRow?.rank === r.rank}
+                t={t}
+              />
+            ))}
+          </div>
+
+          {/* Sticky self-row when me is not in visible list */}
+          {!meIsVisible && me && (
+            <div
+              style={{
+                position: 'sticky',
+                bottom: 16,
+                marginTop: 16,
+                background: 'var(--surface)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--r-md)',
+                boxShadow: 'var(--shadow-md)',
+              }}
+            >
+              <RankRow
+                row={{ rank: me.rank, user_id: 0, name: t('you'), xp: me.xp, level: 0 }}
+                isMe
+                t={t}
+              />
+            </div>
+          )}
+
+          {/* Guest CTA when no "me" data returned */}
+          {!me && (
+            <div
+              style={{
+                position: 'sticky',
+                bottom: 16,
+                marginTop: 16,
+                background: 'var(--surface)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--r-md)',
+                boxShadow: 'var(--shadow-md)',
+                padding: '14px 20px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 12,
+                flexWrap: 'wrap',
+              }}
+            >
+              <span style={{ color: 'var(--text-muted)', fontSize: 14 }}>{t('guestCta')}</span>
+              <Link href="/signin" className="btn btn-primary" style={{ textDecoration: 'none' }}>
+                {t('signIn')}
+              </Link>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/next/components/learn/leaderboard.tsx
+++ b/next/components/learn/leaderboard.tsx
@@ -226,7 +226,9 @@ export function LeaderboardView() {
   }
 
   const podiumRows = rows.slice(0, 3);
-  const listRows = rows.slice(3);
+  // When fewer than 3 rows exist the podium doesn't render, so show all rows in
+  // the list instead of only rank-4+ entries (which would be an empty slice).
+  const listRows = rows.length >= 3 ? rows.slice(3) : rows;
 
   // Find "me" row inside the full list (to highlight inline too)
   const meRow = me ? rows.find((r) => r.rank === me.rank) : null;

--- a/next/components/learn/leaderboard.tsx
+++ b/next/components/learn/leaderboard.tsx
@@ -3,12 +3,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter, useSearchParams } from 'next/navigation';
+import axios from 'axios';
 import { Link } from '@/i18n/navigation';
 import { Icon } from '@/components/ui/icon';
 import { getLeaderboard } from '@/lib/api/gamification';
 import type { LeaderboardRow, LeaderboardMe, LeaderboardPeriod } from '@/lib/api/gamification';
 
-type LeaderboardState = 'loading' | 'error' | 'empty' | 'active';
+type LeaderboardState = 'loading' | 'error' | 'empty' | 'active' | 'guest';
 
 const PERIODS: { id: LeaderboardPeriod; labelKey: string }[] = [
   { id: 'week', labelKey: 'periodWeek' },
@@ -210,8 +211,13 @@ export function LeaderboardView() {
         setMe(res.me);
         setState('active');
       }
-    } catch {
-      setState('error');
+    } catch (err) {
+      // 401 means the endpoint requires auth — treat as guest, not a real error.
+      if (axios.isAxiosError(err) && err.response?.status === 401) {
+        setState('guest');
+      } else {
+        setState('error');
+      }
     }
   }, [period]);
 
@@ -299,6 +305,16 @@ export function LeaderboardView() {
               }}
             />
           ))}
+        </div>
+      )}
+
+      {/* Guest: leaderboard requires auth — show sign-in CTA instead of error */}
+      {state === 'guest' && (
+        <div className="card fade-up" style={{ padding: 40, textAlign: 'center', maxWidth: 480, margin: '0 auto' }}>
+          <p style={{ color: 'var(--text-muted)', marginBottom: 20 }}>{t('guestCta')}</p>
+          <Link href="/signin" className="btn btn-primary" style={{ textDecoration: 'none' }}>
+            {t('signIn')}
+          </Link>
         </div>
       )}
 

--- a/next/components/learn/srs-session.tsx
+++ b/next/components/learn/srs-session.tsx
@@ -12,9 +12,6 @@ import { getDueCards, gradeCard } from '@/lib/api/srs';
 import { getGamificationMe } from '@/lib/api/gamification';
 import type { SrsDueItem, GamificationMe } from '@/lib/api/types';
 
-// XP за каждую оценённую карточку (косметический фикс, бэк не возвращает xpDelta)
-const XP_PER_CARD = 10;
-
 type SessionState = 'loading' | 'error' | 'unauthorized' | 'empty' | 'active' | 'complete';
 
 export function SrsSession(): ReactElement {

--- a/next/components/learn/srs-session.tsx
+++ b/next/components/learn/srs-session.tsx
@@ -33,6 +33,10 @@ export function SrsSession(): ReactElement {
 
   // Track whether this session's XP crossed the daily goal
   const xpTodayRef = useRef<number>(0);
+  // Monotonically-incrementing key so XpToast remounts on every grade, even
+  // when the awarded XP amount is identical to the previous card (same number
+  // would otherwise be a React state no-op and skip the toast animation).
+  const xpToastSeqRef = useRef<number>(0);
 
   const load = useCallback(async () => {
     setState('loading');
@@ -89,6 +93,8 @@ export function SrsSession(): ReactElement {
 
     setGraded(nextGraded);
     setXp(nextXp);
+    // Bump seq so XpToast always remounts, even when awardedXp equals the last value.
+    xpToastSeqRef.current += 1;
     setXpToast(awardedXp);
 
     // Check if daily goal crossed during this session
@@ -319,8 +325,9 @@ export function SrsSession(): ReactElement {
         onFinish={handleFinish}
       />
 
-      {/* XP micro-toast */}
-      <XpToast amount={xpToast} onDone={() => setXpToast(null)} />
+      {/* XP micro-toast — key forces remount on every grade so the animation
+          fires even when two consecutive cards award the same XP amount. */}
+      <XpToast key={xpToastSeqRef.current} amount={xpToast} onDone={() => setXpToast(null)} />
     </>
   );
 }

--- a/next/components/learn/srs-session.tsx
+++ b/next/components/learn/srs-session.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { useCallback, useEffect, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import { Icon } from '@/components/ui/icon';
 import { Link } from '@/i18n/navigation';
 import { SrsCardView } from '@/components/learn/srs-card';
+import { XpToast } from '@/components/learn/xp-toast';
 import { getDueCards, gradeCard } from '@/lib/api/srs';
-import type { SrsDueItem } from '@/lib/api/types';
+import { getGamificationMe } from '@/lib/api/gamification';
+import type { SrsDueItem, GamificationMe } from '@/lib/api/types';
 
 // XP за каждую оценённую карточку (косметический фикс, бэк не возвращает xpDelta)
 const XP_PER_CARD = 10;
@@ -17,6 +19,7 @@ type SessionState = 'loading' | 'error' | 'unauthorized' | 'empty' | 'active' | 
 
 export function SrsSession(): ReactElement {
   const t = useTranslations('learn.srs');
+  const tHud = useTranslations('learn.hud');
   const router = useRouter();
 
   const [state, setState] = useState<SessionState>('loading');
@@ -25,10 +28,28 @@ export function SrsSession(): ReactElement {
   const [graded, setGraded] = useState(0);
   const [xp, setXp] = useState(0);
 
+  // Session-HUD gamification state
+  const [gamification, setGamification] = useState<GamificationMe | null>(null);
+  const [xpToast, setXpToast] = useState<number | null>(null);
+  const [goalJustMet, setGoalJustMet] = useState(false);
+  const [streakJustGained, setStreakJustGained] = useState(false);
+
+  // Track whether this session's XP crossed the daily goal
+  const xpTodayRef = useRef<number>(0);
+
   const load = useCallback(async () => {
     setState('loading');
     try {
-      const res = await getDueCards();
+      const [res, me] = await Promise.all([
+        getDueCards(),
+        getGamificationMe().catch(() => null), // non-critical
+      ]);
+
+      if (me) {
+        setGamification(me);
+        xpTodayRef.current = me.xp_today;
+      }
+
       if (res.count === 0 || res.items.length === 0) {
         setState('empty');
       } else {
@@ -62,8 +83,25 @@ export function SrsSession(): ReactElement {
       // оптимистичный переход, потеря одной оценки некритична для UX
     }
 
-    setGraded((n) => n + 1);
-    setXp((n) => n + XP_PER_CARD);
+    const awardedXp = grade >= 5 ? 15 : grade >= 3 ? 10 : 2;
+    const nextGraded = graded + 1;
+    const nextXp = xp + awardedXp;
+
+    setGraded(nextGraded);
+    setXp(nextXp);
+    setXpToast(awardedXp);
+
+    // Check if daily goal crossed during this session
+    if (gamification && !goalJustMet && !gamification.goal_met) {
+      const newXpToday = xpTodayRef.current + nextXp;
+      if (newXpToday >= gamification.daily_goal_xp) {
+        setGoalJustMet(true);
+        // Streak increments when daily goal is met — celebrate
+        if (gamification.streak >= 0) {
+          setStreakJustGained(true);
+        }
+      }
+    }
 
     if (index + 1 >= items.length) {
       setState('complete');
@@ -177,9 +215,22 @@ export function SrsSession(): ReactElement {
         <p style={{ color: 'var(--text-muted)', marginBottom: 4 }}>
           {t('completeBody', { count: graded })}
         </p>
-        <p style={{ color: 'var(--accent-warm)', fontWeight: 700, marginBottom: 24, fontSize: 18 }}>
+        <p style={{ color: 'var(--accent-warm)', fontWeight: 700, marginBottom: streakJustGained ? 4 : 24, fontSize: 18 }}>
           🔥 {t('xp', { xp })}
         </p>
+        {streakJustGained && (
+          <p
+            style={{
+              color: 'var(--accent-green)',
+              fontWeight: 700,
+              marginBottom: 24,
+              fontSize: 15,
+              animation: 'pulse-soft 2s ease-in-out 3',
+            }}
+          >
+            {tHud('streakGained', { streak: (gamification?.streak ?? 0) + 1 })}
+          </p>
+        )}
         <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
           <button type="button" className="btn btn-primary" onClick={() => void load()}>
             <Icon name="play" size={14} /> {t('restart')}
@@ -196,14 +247,80 @@ export function SrsSession(): ReactElement {
   const current = items[index];
   if (!current) return <></>;
 
+  const dailyGoal = gamification?.daily_goal_xp ?? 0;
+  const xpTodayBase = gamification ? xpTodayRef.current : 0;
+  const xpTodayTotal = xpTodayBase + xp;
+  const goalProgress = dailyGoal > 0 ? Math.min(xpTodayTotal / dailyGoal, 1) : 0;
+  const goalColor = goalJustMet ? 'var(--accent-green)' : 'var(--primary)';
+
   return (
-    <SrsCardView
-      item={current}
-      index={index}
-      total={items.length}
-      xpTotal={xp}
-      onGrade={(grade) => void handleGrade(grade)}
-      onFinish={handleFinish}
-    />
+    <>
+      {/* Session-HUD: daily-goal bar */}
+      {gamification && dailyGoal > 0 && (
+        <div
+          style={{
+            maxWidth: 720,
+            margin: '0 auto 12px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+          }}
+          aria-label={tHud('dailyGoalBar', { current: Math.round(xpTodayTotal), goal: dailyGoal })}
+          role="progressbar"
+          aria-valuenow={Math.round(xpTodayTotal)}
+          aria-valuemin={0}
+          aria-valuemax={dailyGoal}
+        >
+          <Icon name="zap" size={14} style={{ color: goalColor, flexShrink: 0 }} />
+          <div
+            style={{
+              flex: 1,
+              height: 6,
+              borderRadius: 999,
+              background: 'var(--surface-2)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: `${goalProgress * 100}%`,
+                borderRadius: 999,
+                background: goalColor,
+                transition: 'width 0.4s ease, background-color 0.4s ease',
+              }}
+            />
+          </div>
+          <span style={{ fontSize: 11, color: 'var(--text-muted)', flexShrink: 0, fontWeight: 600 }}>
+            {Math.round(xpTodayTotal)}/{dailyGoal}
+          </span>
+          {goalJustMet && (
+            <span
+              style={{
+                color: 'var(--accent-green)',
+                fontSize: 11,
+                fontWeight: 700,
+                flexShrink: 0,
+                animation: 'pulse-soft 1.5s ease-in-out 3',
+              }}
+            >
+              {tHud('goalMet')}
+            </span>
+          )}
+        </div>
+      )}
+
+      <SrsCardView
+        item={current}
+        index={index}
+        total={items.length}
+        xpTotal={xp}
+        onGrade={(grade) => void handleGrade(grade)}
+        onFinish={handleFinish}
+      />
+
+      {/* XP micro-toast */}
+      <XpToast amount={xpToast} onDone={() => setXpToast(null)} />
+    </>
   );
 }

--- a/next/components/learn/srs-session.tsx
+++ b/next/components/learn/srs-session.tsx
@@ -54,6 +54,9 @@ export function SrsSession(): ReactElement {
         setIndex(0);
         setGraded(0);
         setXp(0);
+        // Reset celebration flags so a restarted session starts clean.
+        setGoalJustMet(false);
+        setStreakJustGained(false);
         setState('active');
       }
     } catch (err) {

--- a/next/components/learn/xp-toast.tsx
+++ b/next/components/learn/xp-toast.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Icon } from '@/components/ui/icon';
 
@@ -18,6 +18,8 @@ interface XpToastProps {
 export function XpToast({ amount, onDone }: XpToastProps) {
   const t = useTranslations('learn.hud');
   const [visible, setVisible] = useState(false);
+  // Ref for the inner fade-out delay so we can cancel it on unmount.
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!amount) return;
@@ -25,9 +27,17 @@ export function XpToast({ amount, onDone }: XpToastProps) {
     const timer = setTimeout(() => {
       setVisible(false);
       // Give the CSS fade-out time to play before notifying parent.
-      setTimeout(onDone, 300);
+      fadeTimerRef.current = setTimeout(onDone, 300);
     }, 1500);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      // Also cancel the inner fade-out timer so a unmounted instance
+      // never calls onDone and kills the freshly mounted replacement.
+      if (fadeTimerRef.current !== null) {
+        clearTimeout(fadeTimerRef.current);
+        fadeTimerRef.current = null;
+      }
+    };
   }, [amount, onDone]);
 
   if (!amount) return null;

--- a/next/components/learn/xp-toast.tsx
+++ b/next/components/learn/xp-toast.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Icon } from '@/components/ui/icon';
+
+interface XpToastProps {
+  /** Amount of XP to display. Pass null/0 to hide. */
+  amount: number | null;
+  /** Called after the toast finishes its animation so parent can clear state. */
+  onDone: () => void;
+}
+
+/**
+ * Micro-toast that floats up and fades out when XP is awarded.
+ * Rendered inline — parent controls visibility via `amount`.
+ */
+export function XpToast({ amount, onDone }: XpToastProps) {
+  const t = useTranslations('learn.hud');
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!amount) return;
+    setVisible(true);
+    const timer = setTimeout(() => {
+      setVisible(false);
+      // Give the CSS fade-out time to play before notifying parent.
+      setTimeout(onDone, 300);
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [amount, onDone]);
+
+  if (!amount) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      style={{
+        position: 'fixed',
+        bottom: 88,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 200,
+        pointerEvents: 'none',
+        animation: visible
+          ? 'fadeUp 0.3s ease both'
+          : 'fadeDown 0.3s ease both forwards',
+      }}
+    >
+      <span
+        className="chip chip-warm"
+        style={{
+          fontSize: 15,
+          fontWeight: 800,
+          padding: '8px 18px',
+          boxShadow: 'var(--shadow-md)',
+          gap: 6,
+        }}
+      >
+        <Icon name="zap" size={15} />
+        {t('xpAwarded', { xp: amount })}
+      </span>
+    </div>
+  );
+}

--- a/next/lib/api/gamification.ts
+++ b/next/lib/api/gamification.ts
@@ -1,0 +1,49 @@
+// Gamification API module — Learn-2, Phase 2 (tmgr 8795-Ф2)
+// TODO(8795-Ф2): сверить с финальным контрактом backend-tl перед релизом
+
+import { apiCall } from './client';
+import type {
+  GamificationMe,
+  LeaderboardResponse,
+  LeaderboardRow,
+  LeaderboardMe,
+} from './types';
+
+// Re-export types so callers can import from one place.
+export type { GamificationMe, LeaderboardResponse, LeaderboardRow, LeaderboardMe };
+
+interface StatsApiResponse {
+  data: GamificationMe;
+}
+
+interface LeaderboardApiResponse {
+  data: LeaderboardRow[];
+  meta: { count: number; me: LeaderboardMe | null };
+}
+
+/** GET /api/stats/me [auth:sanctum] — XP, streak, level, daily-goal */
+export async function getGamificationMe(): Promise<GamificationMe> {
+  const body = await apiCall<StatsApiResponse>('GET', '/api/stats/me');
+  return body.data;
+}
+
+export type LeaderboardPeriod = 'week' | 'all';
+export type LeaderboardScope = 'global';
+
+/** GET /api/leaderboard?period=&limit= [auth:sanctum] */
+export async function getLeaderboard(params?: {
+  period?: LeaderboardPeriod;
+  scope?: LeaderboardScope;
+  limit?: number;
+}): Promise<LeaderboardResponse> {
+  const period = params?.period ?? 'week';
+  const limit = params?.limit ?? 20;
+  const body = await apiCall<LeaderboardApiResponse>(
+    'GET',
+    `/api/leaderboard?period=${period}&limit=${limit}`,
+  );
+  return {
+    rows: body.data,
+    me: body.meta.me,
+  };
+}

--- a/next/lib/api/types.ts
+++ b/next/lib/api/types.ts
@@ -247,3 +247,39 @@ export interface SrsDueResponse {
   items: SrsDueItem[];
   count: number;
 }
+
+// --- Gamification (Learn-2, Phase 2) ---
+// TODO(8795-Ф2): сверить с финальным контрактом backend-tl
+
+/** GET /api/stats/me [auth:sanctum] */
+export interface GamificationMe {
+  xp: number;
+  level: number;
+  streak: number;
+  longest_streak: number;
+  last_active_date: string | null;
+  daily_goal_xp: number;
+  xp_today: number;
+  goal_met: boolean;
+}
+
+/** Строка лидерборда из GET /api/leaderboard */
+export interface LeaderboardRow {
+  rank: number;
+  user_id: number;
+  name: string;
+  xp: number;
+  level: number;
+}
+
+/** Мета «своей» позиции из GET /api/leaderboard */
+export interface LeaderboardMe {
+  rank: number;
+  xp: number;
+}
+
+/** GET /api/leaderboard?period=all|week&limit=20 [auth:sanctum] */
+export interface LeaderboardResponse {
+  rows: LeaderboardRow[];
+  me: LeaderboardMe | null;
+}

--- a/next/messages/bur.json
+++ b/next/messages/bur.json
@@ -273,6 +273,31 @@
         "good": "Һайн",
         "easy": "Хялбар"
       }
+    },
+    "hud": {
+      "ariaLabel": "{streak} үдэрэй дараалал · {xp} XP · {level}",
+      "streakAtRisk": "Дараалалаа алдангүйн тулада мүнѳѳ hурагты",
+      "streakGained": "Дараалал +1! Аль хэдэн {streak} үдэр 🔥",
+      "xpAwarded": "+{xp} XP",
+      "dailyGoalBar": "Үдэрэй зорилго: {current} — {goal} XP",
+      "goalMet": "Зорилго бэелүүлэгдэбэ!"
+    },
+    "leaderboard": {
+      "title": "Лидерборд",
+      "periodWeek": "7 үдэр",
+      "periodAll": "Бүхы сагтаа",
+      "scopeGlobal": "Дэлхэйн рейтинг",
+      "podiumLabel": "Топ-3",
+      "you": "Та",
+      "deltaUp": "{n} байра дээшэлбэ",
+      "deltaDown": "{n} байра доошолбо",
+      "deltaStable": "хубилаагүй",
+      "error": "Рейтинг ачаалагдаагүй",
+      "retry": "Дахяа оролдохо",
+      "empty": "Мэдээн алга — hурахаа эхилжэ топ-оор оро",
+      "startLearning": "hурахаа эхилхэ",
+      "guestCta": "Мүрысэхын тулада нэбтэрэгты",
+      "signIn": "Нэбтэрхэ"
     }
   },
   "quiz": {

--- a/next/messages/en.json
+++ b/next/messages/en.json
@@ -275,6 +275,31 @@
         "good": "Good",
         "easy": "Easy"
       }
+    },
+    "hud": {
+      "ariaLabel": "{streak}-day streak · {xp} XP · {level}",
+      "streakAtRisk": "Practice today to keep your streak",
+      "streakGained": "Streak +1! {streak} days in a row 🔥",
+      "xpAwarded": "+{xp} XP",
+      "dailyGoalBar": "Daily goal: {current} of {goal} XP",
+      "goalMet": "Goal reached!"
+    },
+    "leaderboard": {
+      "title": "Leaderboard",
+      "periodWeek": "This week",
+      "periodAll": "All time",
+      "scopeGlobal": "Global rankings",
+      "podiumLabel": "Top 3 leaders",
+      "you": "You",
+      "deltaUp": "moved up {n} places",
+      "deltaDown": "moved down {n} places",
+      "deltaStable": "no change",
+      "error": "Couldn't load the leaderboard",
+      "retry": "Retry",
+      "empty": "No data yet — start learning to make the top",
+      "startLearning": "Start learning",
+      "guestCta": "Sign in to compete",
+      "signIn": "Sign in"
     }
   },
   "quiz": {

--- a/next/messages/ru.json
+++ b/next/messages/ru.json
@@ -274,6 +274,31 @@
         "good": "Хорошо",
         "easy": "Легко"
       }
+    },
+    "hud": {
+      "ariaLabel": "Серия {streak} дней · {xp} XP · {level}",
+      "streakAtRisk": "Позанимайся сегодня, чтобы не потерять серию",
+      "streakGained": "Серия +1! Уже {streak} дней подряд 🔥",
+      "xpAwarded": "+{xp} XP",
+      "dailyGoalBar": "Дневная цель: {current} из {goal} XP",
+      "goalMet": "Цель выполнена!"
+    },
+    "leaderboard": {
+      "title": "Лидерборд",
+      "periodWeek": "Неделя",
+      "periodAll": "Всё время",
+      "scopeGlobal": "Глобальный рейтинг",
+      "podiumLabel": "Топ-3 лидеров",
+      "you": "Вы",
+      "deltaUp": "поднялся на {n} позиции",
+      "deltaDown": "опустился на {n} позиции",
+      "deltaStable": "без изменений",
+      "error": "Не удалось загрузить рейтинг",
+      "retry": "Повторить",
+      "empty": "Пока нет данных — начни заниматься и попади в топ",
+      "startLearning": "Начать учиться",
+      "guestCta": "Войди, чтобы соревноваться",
+      "signIn": "Войти"
     }
   },
   "quiz": {

--- a/next/middleware.ts
+++ b/next/middleware.ts
@@ -4,7 +4,8 @@ import { routing } from './i18n/routing';
 
 const intlMiddleware = createMiddleware(routing);
 
-const PROTECTED = /^\/(ru|bur|en)\/(profile|packs|admin|learn)(\/|$)/;
+// /learn/leaderboard is public (shows top without auth, guest sees sign-in CTA)
+const PROTECTED = /^\/(ru|bur|en)\/(profile|packs|admin|learn(?!\/leaderboard))(\/|$)/;
 const AUTH_COOKIE = 'token';
 
 export default function middleware(req: NextRequest) {


### PR DESCRIPTION
## 8795 · Фаза 2 — Геймификация: HUD streak/XP + лидерборд

База: `feat/learn2-platform` (← `feat/learn1-srs`). Спека: `docs/agent-team/design/learn-phase2-hud-leaderboard.md`.

### Сделано
- **Глобальный HUD в хедере** (`gamification-hud.tsx`): streak 🔥 / XP ◆ / уровень CEFR. Скрыт для гостя. streak-at-risk → flame `pulse-soft` + tooltip; streak=0 → серый; loading → скелетон.
- **Mobile HUD**: компактный chip `🔥streak·XP`, переключение desktop/mobile через `.hide-sm`/`.show-sm` на одном брейкпоинте (≤720px), тап-таргет ≥44px.
- **+N XP micro-toast** при начислении.
- **Session-HUD в /learn**: session-XP + daily-goal бар + «Серия +1!». gamification-фетч изолирован (`Promise.all`+`.catch`) — регрессии Learn-1 нет.
- **Страница `/learn/leaderboard`**: фильтры периода, подиум топ-3, ranked-rows, sticky-self (`aria-current`), состояния loading/empty/error/гость(CTA). Маршрут публичный через `middleware.ts`.
- **Токен `--bronze`** (+soft) в `globals.css` light+dark.
- **i18n** `learn.hud.*` + `learn.leaderboard.*` ×3, a11y.

### Проверки
- `typecheck` 0 · `lint` чисто (warning только в стороннем `translation-results.tsx`).

### Pending backend contract (правка одного модуля `lib/api/gamification.ts`)
- Пути предположены: `GET /api/stats/me`, `GET /api/leaderboard?period=&limit=` — жду боевой контракт от backend-tl.
- `avatarUrl` + `delta`(↑/↓) в строках лидерборда (спека §3) — добавятся по подтверждении полей бэком.
- Лиги — stretch, вне MVP.